### PR TITLE
Refactors search mechanics: Part 1

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -1,31 +1,34 @@
-import React, { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSearch, faTimesCircle } from '@fortawesome/free-solid-svg-icons'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 import { SearchContext } from 'context/search-context'
 
 import 'assets/css/forms.css'
 import './SearchBar.css'
 
+import { AND, OR } from 'constants'
+import { useSearchParams } from 'hooks'
+import { getQueryString } from 'utils/query'
+
 const SearchBar = () => {
-  const navigate = useNavigate()
-
   const searchContext = useContext(SearchContext)
+  const [searchParams, setSearchParams] = useSearchParams()
 
-  const [searchQuery, setSearchQuery] = React.useState('')
-  const [searchQuery1, setSearchQuery1] = React.useState('')
-  const [searchQuery2, setSearchQuery2] = React.useState('')
-  const [searchQuery3, setSearchQuery3] = React.useState('')
-  const [searchQuery4, setSearchQuery4] = React.useState('')
-  const [searchQuery5, setSearchQuery5] = React.useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchQuery1, setSearchQuery1] = useState('')
+  const [searchQuery2, setSearchQuery2] = useState('')
+  const [searchQuery3, setSearchQuery3] = useState('')
+  const [searchQuery4, setSearchQuery4] = useState('')
+  const [searchQuery5, setSearchQuery5] = useState('')
 
   let counter = 0
 
   const searchQueryHandler = (e) => {
     //e.preventDefault();
 
-    searchContext.loadingHandler('true')
+    searchContext.loadingHandler(true)
 
     /*   if (props.isHome) {
 
@@ -40,24 +43,24 @@ const SearchBar = () => {
       searchContext.searchHandler(searchQuery)
 
       if (counter === 0) {
-        searchContext.searchArrayHandler(searchQuery1)
+        searchContext.addQueryHandler(searchQuery1)
         counter++
       }
       if (counter === 1 && searchQuery1 !== searchQuery2 && searchQuery2) {
-        searchContext.searchArrayHandler(searchQuery2)
+        searchContext.addQueryHandler(searchQuery2)
         counter++
       }
       if (counter === 2 && searchQuery2 !== searchQuery3 && searchQuery3) {
-        searchContext.searchArrayHandler(searchQuery3)
+        searchContext.addQueryHandler(searchQuery3)
         counter++
       }
     }
     if (counter === 3 && searchQuery3 !== searchQuery4 && searchQuery4) {
-      searchContext.searchArrayHandler(searchQuery4)
+      searchContext.addQueryHandler(searchQuery4)
       counter++
     }
     if (counter === 4 && searchQuery4 !== searchQuery5 && searchQuery5) {
-      searchContext.searchArrayHandler(searchQuery5)
+      searchContext.addQueryHandler(searchQuery5)
       counter++
     }
 
@@ -68,79 +71,48 @@ const SearchBar = () => {
     if (e.key === 'Enter') {
       e.preventDefault()
       setCurrentQuery(e)
-      navigate(`/results?q=${e.target.value}&doctype=activity,entity`)
+      setSearchParams(
+        { q: searchQuery.trim(), operator: searchContext.searchOperator },
+        { requestedPathname: '/results' }
+      )
     }
   }
 
   const setCurrentQuery = (e) => {
     e.preventDefault()
-
-    let query = e.target.value
-
+    const query = e.target.value
     setSearchQuery(query)
 
-    if (counter === 0) {
-      setSearchQuery1(query)
-    } else if (counter === 1) {
-      setSearchQuery2(query)
-    } else if (counter === 2) {
-      setSearchQuery3(query)
-    } else if (counter === 3) {
-      setSearchQuery4(query)
-    } else if (counter === 4) {
-      setSearchQuery5(query)
-    }
-
-    //handleTotalQuery(query)
+    // if (counter === 0) {
+    //   setSearchQuery1(query)
+    // } else if (counter === 1) {
+    //   setSearchQuery2(query)
+    // } else if (counter === 2) {
+    //   setSearchQuery3(query)
+    // } else if (counter === 3) {
+    //   setSearchQuery4(query)
+    // } else if (counter === 4) {
+    //   setSearchQuery5(query)
+    // }
   }
 
-  /*  const handleTotalQuery = (query) => {
-  
-    if (searchQuery1 && searchQuery2 && searchQuery3 && searchQuery4 && searchQuery5) {
-      setTotalQuery(searchQuery1+'+'+searchQuery2+'+'+searchQuery3+'+'+searchQuery4+'+'+query)
-  
-    }
-  
-    else if (searchQuery1 && searchQuery2 && searchQuery3 && searchQuery4) {
-      setTotalQuery(searchQuery1+'+'+searchQuery2+'+'+searchQuery3+'+'+query)
-  
-    }
-  
-    else if (searchQuery1 && searchQuery2 && searchQuery3) {
-      setTotalQuery(searchQuery1+'+'+searchQuery2+'+'+query)
-  
-    }
-    else if (searchQuery1 && searchQuery2) {
-      setTotalQuery(searchQuery1+'+'+query)
-    }
-    else {
-      setTotalQuery(query)
-    } 
-  
-    
-   }
-   */
-  const removeQuery = (query) => {
-    searchContext.loadingHandler('true')
+  const removeQuery = ({ key, query }) => {
+    searchContext.loadingHandler(true)
+    console.log({ key, query })
 
-    /* const newArray = searchArray.splice(key, 1)
-    setSearchArray(newArray) */
-
-    if (searchQuery1 === query.query) {
+    if (searchQuery1 === query) {
       setSearchQuery1('')
-    } else if (searchQuery2 === query.query) {
+    } else if (searchQuery2 === query) {
       setSearchQuery2('')
-    } else if (searchQuery3 === query.query) {
+    } else if (searchQuery3 === query) {
       setSearchQuery3('')
     }
 
-    searchContext.searchArray.splice(query.key, 1)
+    searchContext.removeQueryHandler(query)
 
-    if (!searchContext.searchArray) {
-      setSearchQuery('')
-    }
-
-    //handleTotalQuery(query)
+    // if (!searchContext.searchArray) {
+    //   setSearchQuery('')
+    // }
 
     counter--
 
@@ -179,9 +151,11 @@ const SearchBar = () => {
   
     }; */
 
-  const orCheckHandler = async (e) => {
-    await searchContext.orHandler(e.target.checked)
-  }
+  const newSearchQuery = getQueryString({
+    ...searchParams,
+    q: searchQuery,
+    operator: searchContext.searchOperator,
+  })
 
   return (
     <div className="container pb-3 pt-1 mt-1">
@@ -189,18 +163,18 @@ const SearchBar = () => {
         <div className="row">
           <div className="col-2"></div>
           <div className="col-5 inter-bar">
-            {searchContext.searchArray.map((query, i) => {
+            {searchContext.searchArray.map((searchTerm, i) => {
               return (
                 // TODO: Replace i with data relevant id
                 <div className="search-query border col-2 ps-3 rounded-pill" key={i}>
-                  {query}
+                  {searchTerm}
                   {/*  <Link  to={`/results?q=${totalQuery.replace(('+'+query),"")}&filter=activity,entity`}>
                   <FontAwesomeIcon transform="right-15" onClick={() => removeQuery({query})} icon={faTimesCircle} />
                   </Link> */}
                   <div className="mx-auto" size="sm">
                     <FontAwesomeIcon
                       className="remove-query"
-                      onClick={() => removeQuery({ query, key: i })}
+                      onClick={() => removeQuery({ query: searchTerm, key: i })}
                       icon={faTimesCircle}
                     />
                   </div>
@@ -237,11 +211,12 @@ const SearchBar = () => {
                 <input
                   className="form-check-input form__input"
                   type="radio"
-                  id="and-search-select"
-                  name="entity"
-                  onChange={(e) => orCheckHandler(e)}
+                  id="and-operator-select"
+                  name="operator-select"
+                  checked={searchContext.searchOperator === AND}
+                  onChange={() => searchContext.setOperatorHandler(AND)}
                 />
-                <label htmlFor="and-search-select" className="form__radio-label">
+                <label htmlFor="and-operator-select" className="form__radio-label">
                   And
                 </label>
               </div>
@@ -249,11 +224,12 @@ const SearchBar = () => {
                 <input
                   className="form-check-input form__input"
                   type="radio"
-                  id="or-search-select"
-                  name="entity"
-                  onChange={(e) => orCheckHandler(e)}
+                  id="or-operator-select"
+                  name="operator-select"
+                  checked={searchContext.searchOperator === OR}
+                  onChange={() => searchContext.setOperatorHandler(OR)}
                 />
-                <label htmlFor="or-search-select" className="form__radio-label">
+                <label htmlFor="or-operator-select" className="form__radio-label">
                   Or
                 </label>
               </div>
@@ -261,10 +237,8 @@ const SearchBar = () => {
               <div>
                 <Link
                   className="btn btn-primary ps-4 pe-4 rounded-pill mx-auto"
-                  onClick={searchQueryHandler}
-                  to={`/results?q=${searchContext.searchArray.join(
-                    '$'
-                  )}&doctype=activity,entity&operator=Or`}
+                  // onClick={searchQueryHandler}
+                  to={`/results${newSearchQuery}`}
                 >
                   Search <FontAwesomeIcon icon={faSearch} />
                 </Link>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,26 @@
+export const allowedSearchParams = ['q', 'operator', 'doctype']
+
+export const AND = 'and'
+export const OR = 'or'
+
+export const allowedOperators = [AND, OR]
+export const defaultOperator = AND
+
+export const ACTIVITY = 'activity'
+export const ORGANIZATION = 'organization'
+
+export const allowedDoctypes = [ACTIVITY, ORGANIZATION]
+export const defaultDoctype = [ACTIVITY, ORGANIZATION]
+
+export const provinces = [
+  'Alberta',
+  'British Columbia',
+  'Manitoba',
+  'New Brunswick',
+  'Newfoundland and Labrador',
+  'Nova Scotia',
+  'Ontario',
+  'Prince Edward Island',
+  'Quebec',
+  'Saskatchewan',
+]

--- a/src/context/search-context.js
+++ b/src/context/search-context.js
@@ -1,48 +1,57 @@
-import React, { useState } from "react";
+import { createContext, useState } from 'react'
 
-// query is the state
-// SearchHandler is a function for changing the state.
-export const SearchContext = React.createContext({
-  query: "",
+import { AND, allowedOperators } from 'constants'
+
+export const SearchContext = createContext({
+  query: '',
   searchHandler: () => {},
-});
+})
 
-// Defining a simple HOC component
-const SearchContextProvider = (props) => {
-  const [query, setQuery] = useState("");
-  const [searchArray, setSearchArray] = useState([])
-  const [loading, setLoading] = useState('false')
-  const [orFunctionality, setOrFunctionality] = useState(false)
+const SearchContextProvider = ({ children }) => {
+  const [inputFieldQuery, setInputFieldQuery] = useState('')
+  const [allQueries, setAllQueries] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [searchOperator, setSearchOperator] = useState(AND)
 
-  const searchHandler = (query) => {
-    setQuery(query);
-  };
-
-  const searchArrayHandler = (query) => {
-    searchArray.push(query)
-    setSearchArray(searchArray);
-  };
-
-  const loadingHandler = (item) => {
-    setLoading(item)
+  const searchHandler = (newQuery) => {
+    setInputFieldQuery(newQuery)
   }
 
-  const orHandler = (item) => {
-    setOrFunctionality(item)
+  const addQueryHandler = (newQuery) => {
+    setAllQueries([...allQueries, newQuery])
   }
-  
+
+  const removeQueryHandler = (removeQuery) => {
+    setAllQueries(allQueries.filter((query) => query !== removeQuery))
+  }
+
+  const isLoadingHandler = (newIsLoading) => {
+    setIsLoading(newIsLoading)
+  }
+
+  const setOperatorHandler = (newOperator) => {
+    if (!allowedOperators.includes(newOperator)) return
+
+    setSearchOperator(newOperator)
+  }
+
   return (
     <SearchContext.Provider
-      value={{ 
-          query: query, searchHandler: searchHandler,
-          searchArray: searchArray, searchArrayHandler: searchArrayHandler,
-          loading: loading, loadingHandler: loadingHandler,
-          orFunctionality: orFunctionality, orHandler: orHandler,
-        }}
+      value={{
+        query: inputFieldQuery,
+        searchHandler,
+        searchArray: allQueries,
+        addQueryHandler,
+        removeQueryHandler,
+        loading: isLoading,
+        loadingHandler: isLoadingHandler,
+        searchOperator,
+        setOperatorHandler,
+      }}
     >
-      {props.children}
+      {children}
     </SearchContext.Provider>
-  );
-};
+  )
+}
 
-export default SearchContextProvider;
+export default SearchContextProvider

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,2 @@
+export { useMountEffect } from './useMountEffect'
+export { useSearchParams } from './useSearchParams'

--- a/src/hooks/useMountEffect.js
+++ b/src/hooks/useMountEffect.js
@@ -1,0 +1,4 @@
+import { useEffect } from 'react'
+
+// eslint-disable-next-line react-hooks/exhaustive-deps
+export const useMountEffect = (effect) => useEffect(effect, [])

--- a/src/hooks/useSearchParams.js
+++ b/src/hooks/useSearchParams.js
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import queryString from 'query-string'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { pick } from 'lodash'
+
+import { allowedSearchParams } from 'constants'
+import { getQueryString } from 'utils/query'
+
+export const useSearchParams = () => {
+  const navigate = useNavigate()
+  const { pathname, search } = useLocation()
+
+  const currentSearchParams = queryString.parse(search, { arrayFormat: 'comma' })
+
+  return useMemo(() => {
+    const modifySearchParams = (newSearchParams, options = {}) => {
+      const { overwrite = false, replace = false, requestedPathname } = options
+
+      const combinedSearchParams = {
+        ...(!overwrite && currentSearchParams),
+        ...newSearchParams,
+      }
+
+      const filteredSearchParams = pick(combinedSearchParams, allowedSearchParams)
+
+      navigate(
+        `${requestedPathname || pathname}${getQueryString(filteredSearchParams)}`,
+        {
+          replace,
+        }
+      )
+    }
+
+    return [currentSearchParams, modifySearchParams]
+  }, [currentSearchParams, navigate, pathname])
+}

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -1,0 +1,10 @@
+import queryString from 'query-string'
+
+export const getQueryString = (keyVals) => {
+  const query = queryString.stringify(keyVals, {
+    arrayFormat: 'comma',
+    skipNull: true,
+  })
+
+  return query.length ? `?${query}` : ''
+}

--- a/src/views/ActivitiesPage.js
+++ b/src/views/ActivitiesPage.js
@@ -17,7 +17,11 @@ const NoOrgBox = (props) => (
         organization link below to search the database for this organization by its legal
         name:
       </div>
-      <Link to={`/results/?q=${encodeURI(props.recip_legal_name)}&filter=entity`}>
+      <Link
+        to={`/results/?q=${encodeURI(
+          props.recip_legal_name.replace(/\s/g, '+')
+        )}&doctype=organization`}
+      >
         {props.recip_legal_name}
       </Link>
     </div>
@@ -183,7 +187,7 @@ export default class ActPage extends Component {
   }
 
   async getEntitiesData() {
-    if (this.state.org_redirect !== undefined) {
+    if (this.state.org_redirect) {
       const url = `https://sks-server-ajah-ttwto.ondigitalocean.app/entities/${this.state.org_redirect}`
       await axios
         .get(url)

--- a/src/views/HomePage.js
+++ b/src/views/HomePage.js
@@ -71,7 +71,7 @@ export default class HomePage extends Component {
             </div>
           </div>
         </section>
-        <SearchBar isHome="true" />
+        <SearchBar />
         <section>
           <TypesSection />
         </section>

--- a/src/views/ResultsPage.js
+++ b/src/views/ResultsPage.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import { Component } from 'react'
 import axios from 'axios'
 import queryString from 'query-string'
 import { Link } from 'react-router-dom'
@@ -12,23 +12,22 @@ import { SearchContext } from 'context/search-context'
 import 'assets/css/styles.css'
 import './ResultsPage.css'
 
-function Badge(props) {
-  const type = props.type
+const Badge = ({ type }) => {
   if (type === 'activity') {
     return <span className="badge badge-primary">Activity</span>
-  } else if (type === 'entity') {
-    return <span className="badge bg-primary">Organization</span>
-  } else {
-    return ''
   }
+
+  if (type === 'entity') {
+    return <span className="badge bg-primary">Organization</span>
+  }
+
+  return null
 }
 
 const Row = (props) => (
   <tr>
     <td>
       <div>
-        {/* <a href={props.url}>{props.name}</a> */}
-
         <Link to={props.url}>{props.name}</Link>
       </div>
     </td>

--- a/src/views/ResultsPage.js
+++ b/src/views/ResultsPage.js
@@ -1,14 +1,31 @@
-import { Component } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import axios from 'axios'
-import queryString from 'query-string'
 import { Link } from 'react-router-dom'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faSearch } from '@fortawesome/free-solid-svg-icons'
+// import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+// import { faSearch } from '@fortawesome/free-solid-svg-icons'
 
 import { SearchBar } from 'components/SearchBar'
-
 import { SearchContext } from 'context/search-context'
+import { useSearchParams } from 'hooks'
 
+import {
+  allowedSearchParams,
+
+  // Operators
+  allowedOperators,
+  defaultOperator,
+
+  // Types
+  ACTIVITY,
+  ORGANIZATION,
+  allowedDoctypes,
+  defaultDoctype,
+
+  // Other constants
+  // provinces,
+} from 'constants'
+
+// TODO: move styles.css import into ResultsPage.css
 import 'assets/css/styles.css'
 import './ResultsPage.css'
 
@@ -45,331 +62,333 @@ const Row = (props) => (
   </tr>
 )
 
-export default class ResultsPage extends Component {
-  static contextType = SearchContext
+const TableRows = ({ results }) => {
+  return results.map((hit) => {
+    const { _id, _index, _source } = hit
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      total: '',
-      results: [],
-      // filterParams: ["activity", "entity"],
-      act_total: '',
-      ent_total: '',
-      inc_activities: true,
-      inc_entities: true,
-      contextState: '',
-      filter: ['activity', 'entity'],
-      globalQuery: '',
-      queryProp: [],
-      provinces: [
-        'Alberta',
-        'British Columbia',
-        'Manitoba',
-        'New Brunswick',
-        'Newfoundland and Labrador',
-        'Nova Scotia',
-        'Ontario',
-        'Prince Edward Island',
-        'Quebec',
-        'Saskatchewan',
-      ],
-      city: '',
-      location: [],
-      region: '',
-      municipality: '',
-      downloadData: '',
-      operator: '',
-      downloadLink: '',
+    let name
+    let municipality
+    let region
+    let type
+    let url
 
-      // query: "",
+    if (_index === 'new-activities') {
+      name = _source.grant_title
+      municipality = _source.grant_municipality
+      region = _source.grant_region
+      type = 'activity'
+      url = `/activities/${_source.act_sks_id}`
+    } else if (_index === 'entities') {
+      name = _source.name
+      municipality = _source.location_municipality
+      region = _source.location_region
+      type = 'entity'
+      url = `/entities/${_source.ent_sks_id}`
     }
-  }
+    return (
+      <Row
+        name={name}
+        municipality={municipality}
+        region={region}
+        type={type}
+        url={url}
+        key={_id}
+      />
+    )
+  })
+}
 
-  componentDidMount() {
-    // const parsed = queryString.parse(this.props.location.search)
-    let query = ''
-    let filter = this.state.filter
-    let isRedirect = false
-    let operator = 'and'
+const ResultsPage = () => {
+  const searchContext = useContext(SearchContext)
 
-    if (filter.length === 0) {
-      filter.push('activity')
-      filter.push('entity')
-    }
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [resultsState, setResultsState] = useState({
+    total: '',
+    results: [],
+    act_total: '',
+    ent_total: '',
+    inc_activities: true,
+    inc_entities: true,
+    contextState: '',
+    filter: [ACTIVITY, ORGANIZATION],
+    globalQuery: '',
+    queryProp: [],
+    city: '',
+    location: [],
+    region: '',
+    municipality: '',
+    downloadData: '',
+    operator: '',
+    downloadLink: '',
+  })
 
-    if (!this.context.searchArray[0]) {
-      let queryArray = queryString.parse(window.location.search).q.split(' ')
+  const { q = '', operator = '', doctype = [] } = searchParams
+  // Doctype can be either an array or a string, depending on the num
+  const docTypeStr = doctype.toString()
 
-      if (queryArray[0]) {
-        queryArray.forEach((item) => this.context.searchArrayHandler(item))
+  useEffect(() => {
+    try {
+      if (!q.trim()) {
+        setSearchParams({}, { overwrite: true, replace: true })
+        return
       }
-      //this.context.searchArrayHandler(queryArray)
-      /*  this.setState({
-        queryProp: queryArray
-      }); */
-    }
 
-    if (this.context.orFunctionality) {
-      operator = 'or'
-    }
+      const hasInvalidSearchParams = Object.keys(searchParams).some(
+        (paramName) => !allowedSearchParams.includes(paramName)
+      )
 
-    if (queryString.parse(window.location.search).filter === 'entity') {
-      isRedirect = true
-      filter = 'entity'
+      if (hasInvalidSearchParams) {
+        setSearchParams({}, { replace: true })
+        return
+      }
 
-      this.setState({
-        inc_activities: false,
-        inc_entities: true,
-        filter: this.state.filter.slice(1),
-      })
-    }
+      const parsedOperator = allowedOperators.includes(operator)
+        ? operator
+        : defaultOperator
 
-    if (this.context.searchArray.length > 1 && isRedirect === false) {
-      query = this.context.searchArray.join('+')
-    } else if (this.context.searchArray[0] && isRedirect === false) {
-      query = this.context.searchArray[0]
-    } else {
-      query = queryString.parse(window.location.search).q
-    }
+      if (searchContext.searchOperator !== parsedOperator)
+        searchContext.setOperatorHandler(parsedOperator)
 
-    if (!query.trim()) return
+      const doctypeArr = docTypeStr.split(',')
+      const filteredDoctype = doctypeArr.filter((type) => allowedDoctypes.includes(type))
+      const parsedDoctype = filteredDoctype.length ? filteredDoctype : defaultDoctype
 
-    axios
-      .all([
+      const changedParams =
+        doctypeArr.length !== parsedDoctype.length || operator !== parsedOperator
+
+      if (changedParams) {
+        setSearchParams(
+          { q, doctype: parsedDoctype, operator: parsedOperator },
+          { overwrite: true }
+        )
+
+        return
+      }
+
+      // Backend uses 'entity' keyword to refer to 'organization'
+      const doctypeForApi = parsedDoctype.map((type) =>
+        type === ORGANIZATION ? 'entity' : type
+      )
+      // if (!searchContext.searchArray[0]) {
+      //   let queryArray = (q || '').split(' ')
+
+      //   if (queryArray[0]) {
+      //     // queryArray.forEach((item) => searchContext.addQueryHandler(item))
+      //   }
+      // }
+
+      // if (filter === 'entity') {
+      //   // isRedirect = true
+      //   filter = 'entity'
+
+      //   setResultsState({
+      //     ...resultsState,
+      //     inc_activities: false,
+      //     inc_entities: true,
+      //     filter: resultsState.filter.slice(1),
+      //   })
+      // }
+
+      // if (searchContext.searchArray.length) {
+      //   // query = searchContext.searchArray.join('+')
+      // } else if (searchContext.searchArray[0]) {
+      //   // query = searchContext.searchArray[0]
+      // }
+
+      // TODO: Move all api calls into api service
+      Promise.all([
         axios.get(
           `https://sks-server-ajah-ttwto.ondigitalocean.app/search?q=${encodeURI(
-            query
-          )}&doctype=${filter.toString()}&region=${this.state.location}&municipality=${
-            this.state.municipality
-          }&operator=${operator}`
+            q
+          )}&doctype=${doctypeForApi}&operator=${parsedOperator}&region=${
+            resultsState.location
+          }&municipality=${resultsState.municipality}`
         ),
         axios.get(
           `https://sks-server-ajah-ttwto.ondigitalocean.app/count?q=${encodeURI(
-            query
+            q
           )}&operator=${operator}`
         ),
-      ])
-      .then(
+      ]).then(
         axios.spread((search, count) => {
-          this.setState({
-            results: search['data']['hits'],
-            total: count['data']['new-activities,entities'],
-            act_total: count['data']['new-activities'],
-            ent_total: count['data']['entities'],
-            contextState: this.context,
-            operator: operator,
-          })
-
-          this.context.loadingHandler('false')
-
-          if (this.state.location.length && this.state.municipality) {
-            window.history.pushState(
-              'page2',
-              'Title',
-              `/results?q=${query}&doctype=${filter.toString()}&region=${
-                this.state.location
-              }&municipality=${this.state.municipality}&operator=${this.state.operator}`
-            )
-          } else if (this.state.location.length && !this.state.municipality) {
-            window.history.pushState(
-              'page2',
-              'Title',
-              `/results?q=${query}&doctype=${filter.toString()}&region=${
-                this.state.location
-              }&operator=${this.state.operator}`
-            )
-          } else if (this.state.municipality && !this.state.location.length) {
-            window.history.pushState(
-              'page2',
-              'Title',
-              `/results?q=${query}&doctype=${filter.toString()}&municipality=${
-                this.state.municipality
-              }&operator=${this.state.operator}`
-            )
-          } else {
-            window.history.pushState(
-              'page2',
-              'Title',
-              `/results?q=${query}&doctype=${filter.toString()}&operator=${
-                this.state.operator
-              }`
-            )
-          }
-          this.setState({
-            globalQuery: queryString.parse(window.location.search).q,
-          })
-          if (this.state.globalQuery !== undefined) {
-            const url = `https://sks-server-ajah-ttwto.ondigitalocean.app/search?q=${
-              this.state.globalQuery
-            }&doctype=${filter.toString()}&region=${this.state.location}&municipality=${
-              this.state.municipality
-            }&operator=${this.state.operator}`
-            axios
-              .get(url)
-              .then(() => {
-                this.setState({
-                  downloadLink: `https://sks-server-ajah-ttwto.ondigitalocean.app//download?q=${
-                    this.state.globalQuery
-                  }&doctype=${filter.toString()}&region=${
-                    this.state.location
-                  }&municipality=${this.state.municipality}&operator=${
-                    this.state.operator
-                  }`,
-                })
-              })
-              .catch((error) => console.log(error))
-          } else {
-            console.log('No entity was found')
-          }
+          setResultsState((prevState) => ({
+            ...prevState,
+            results: search.data.hits,
+            total: count.data['new-activities,entities'],
+            act_total: count.data['new-activities'],
+            ent_total: count.data['entities'],
+          }))
+          // searchContext.loadingHandler(false)
+          // if (resultsState.location.length && resultsState.municipality) {
+          //   window.history.pushState(
+          //     'page2',
+          //     'Title',
+          //     `/results?q=${q}&doctype=${filter.toString()}&region=${
+          //       resultsState.location
+          //     }&municipality=${resultsState.municipality}&operator=${resultsState.operator}`
+          //   )
+          // } else if (resultsState.location.length && !resultsState.municipality) {
+          //   window.history.pushState(
+          //     'page2',
+          //     'Title',
+          //     `/results?q=${query}&doctype=${filter.toString()}&region=${
+          //       resultsState.location
+          //     }&operator=${resultsState.operator}`
+          //   )
+          // } else if (resultsState.municipality && !resultsState.location.length) {
+          //   window.history.pushState(
+          //     'page2',
+          //     'Title',
+          //     `/results?q=${query}&doctype=${filter.toString()}&municipality=${
+          //       resultsState.municipality
+          //     }&operator=${resultsState.operator}`
+          //   )
+          // } else {
+          //   window.history.pushState(
+          //     'page2',
+          //     'Title',
+          //     `/results?q=${query}&doctype=${filter.toString()}&operator=${
+          //       resultsState.operator
+          //     }`
+          //   )
+          // }
+          // setResultsState({
+          //   ...resultsState,
+          //   globalQuery: queryString.parse(window.location.search).q,
+          // })
+          // if (resultsState.globalQuery !== undefined) {
+          //   const url = `https://sks-server-ajah-ttwto.ondigitalocean.app/search?q=${
+          //     resultsState.globalQuery
+          //   }&doctype=${filter.toString()}&region=${resultsState.location}&municipality=${
+          //     resultsState.municipality
+          //   }&operator=${resultsState.operator}`
+          //   axios
+          //     .get(url)
+          //     .then(() => {
+          //       setResultsState({
+          //         ...resultsState,
+          //         downloadLink: `https://sks-server-ajah-ttwto.ondigitalocean.app//download?q=${
+          //           resultsState.globalQuery
+          //         }&doctype=${filter.toString()}&region=${
+          //           resultsState.location
+          //         }&municipality=${resultsState.municipality}&operator=${
+          //           resultsState.operator
+          //         }`,
+          //       })
+          //     })
+          //     .catch((error) => console.log(error))
+          // } else {
+          //   console.log('No entity was found')
+          // }
         })
       )
+    } catch (error) {
+      console.log(error)
+    }
+  }, [docTypeStr, operator, q, resultsState.location, resultsState.municipality])
 
-    /*  if (!filter.includes("activity")) {
-       this.setState({
+  // componentDidMount() {
+  // const parsed = queryString.parse(this.props.location.search)
+
+  /*  if (!filter.includes("activity")) {
+       setResultsState({...resultsState, 
          inc_activities: false,
        });
      } else if (!filter.includes("entity")) {
-       this.setState({
+       setResultsState({...resultsState, 
          inc_entities: false,
        });
      } */
+  // }
+
+  // componentDidUpdate() {
+  //   // Typical usage (don't forget to compare props):
+
+  //   if (searchContext.loading) {
+  //     this.componentDidMount()
+  //   }
+  // }
+
+  const setCity = (e) => {
+    setResultsState({ ...resultsState, city: e.target.value })
   }
 
-  componentDidUpdate() {
-    // Typical usage (don't forget to compare props):
-
-    if (this.context.loading === 'true') {
-      this.componentDidMount()
-    }
-  }
-
-  tableRows() {
-    return this.state.results.map((hit) => {
-      let name, municipality, region, type, url
-      // if (hit._index === "activities") {
-      if (hit._index === 'new-activities') {
-        name = hit._source.grant_title
-        municipality = hit._source.grant_municipality
-        region = hit._source.grant_region
-        type = 'activity'
-        url = `/activities/${hit._source.act_sks_id}`
-      } else if (hit._index === 'entities') {
-        name = hit._source.name
-        municipality = hit._source.location_municipality
-        region = hit._source.location_region
-        type = 'entity'
-        url = `/entities/${hit._source.ent_sks_id}`
-      }
-      return (
-        <Row
-          name={name}
-          municipality={municipality}
-          region={region}
-          type={type}
-          url={url}
-          key={hit._id}
-        />
-      )
-    })
-  }
-
-  setCity = (e) => {
-    this.setState({
-      city: e.target.value,
-    })
-  }
-
-  searchCity = (e, city) => {
+  const searchCity = (e, city) => {
     e.preventDefault()
 
-    city = this.state.city
+    city = resultsState.city
 
-    this.setState({
-      municipality: city,
-    })
+    setResultsState({ ...resultsState, municipality: city })
 
-    if (this.state.location) {
+    if (resultsState.location) {
       window.history.pushState(
         'page2',
         'Title',
-        `/results?q=${this.state.globalQuery}&doctype=${this.state.filter.join(
+        `/results?q=${resultsState.globalQuery}&doctype=${resultsState.filter.join(
           ','
-        )}&region=${this.state.location}&municipality=${city}&operator=${
-          this.state.operator
+        )}&region=${resultsState.location}&municipality=${city}&operator=${
+          resultsState.operator
         }`
       )
     } else {
       window.history.pushState(
         'page2',
         'Title',
-        `/results?q=${this.state.globalQuery}&doctype=${this.state.filter.join(
+        `/results?q=${resultsState.globalQuery}&doctype=${resultsState.filter.join(
           ','
-        )}&municipality=${city}&operator=${this.state.operator}`
+        )}&municipality=${city}&operator=${resultsState.operator}`
       )
     }
   }
 
-  handleLocation = (e, city) => {
+  const handleLocation = (e) => {
     //e.preventDefault();
 
     let loc
 
     loc = e.target.name
 
-    if (!this.state.location.includes(loc)) {
-      this.state.location.push(loc)
+    if (!resultsState.location.includes(loc)) {
+      resultsState.location.push(loc)
 
-      this.setState({
-        location: this.state.location,
-      })
-    } else if (this.state.location.includes(loc)) {
-      const index = this.state.location.indexOf(loc)
+      setResultsState({ ...resultsState, location: resultsState.location })
+    } else if (resultsState.location.includes(loc)) {
+      const index = resultsState.location.indexOf(loc)
 
-      this.state.location.splice(index, 1)
+      resultsState.location.splice(index, 1)
 
-      this.setState({
-        location: this.state.location,
-      })
+      setResultsState({ ...resultsState, location: resultsState.location })
     }
 
-    if (this.state.municipality) {
+    if (resultsState.municipality) {
       window.history.pushState(
         'page2',
         'Title',
-        `/results?q=${this.state.globalQuery}&doctype=${this.state.filter.join(
+        `/results?q=${resultsState.globalQuery}&doctype=${resultsState.filter.join(
           ','
-        )}&region=${this.state.location}&municipality=${
-          this.state.municipality
-        }&operator=${this.state.operator}`
+        )}&region=${resultsState.location}&municipality=${
+          resultsState.municipality
+        }&operator=${resultsState.operator}`
       )
     } else {
       window.history.pushState(
         'page2',
         'Title',
-        `/results?q=${this.state.globalQuery}&doctype=${this.state.filter.join(
+        `/results?q=${resultsState.globalQuery}&doctype=${resultsState.filter.join(
           ','
-        )}&region=${this.state.location}&operator=${this.state.operator}`
+        )}&region=${resultsState.location}&operator=${resultsState.operator}`
       )
     }
   }
 
-  handleFilters = (e) => {
-    if (!this.state.filter.includes(e.target.name)) {
-      this.state.filter.push(e.target.name)
-      window.history.pushState(
-        'page2',
-        'Title',
-        `/results?q=${this.state.globalQuery}&doctype=${this.state.filter.join(
-          ','
-        )}&municipality=${this.state.municipality}&operator=${this.state.operator}`
-      )
-    }
+  const handleDoctypeFilter = (e) => {
+    const newDoctype = e.target.value
+    setSearchParams({ doctype: newDoctype.split(',') })
 
     /* 
 
     const parsed = queryString.parse(this.props.location.search);
-    const query =  this.context.query;
+    const query =  searchContext.query;
     const filter = parsed.filter;
   
 
@@ -389,7 +408,7 @@ export default class ResultsPage extends Component {
       ])
       .then(
         axios.spread((search, count) => {
-          this.setState({
+          setResultsState({...resultsState, 
             results: search["data"]["hits"],
             total: count["data"]["new-activities,entities"],
             act_total: count["data"]["new-activities"],
@@ -403,11 +422,11 @@ export default class ResultsPage extends Component {
 
 
     const queryParams = queryString.parse(window.location.search);
-    const filters = this.state.filter;
+    const filters = resultsState.filter;
 
     if (value === true) {
       filters.push(name);
-      this.setState({
+      setResultsState({...resultsState, 
         filter: filters,
       });
       //this.componentDidMount()
@@ -415,56 +434,54 @@ export default class ResultsPage extends Component {
 
     const index = filters.indexOf(name);
 
-    this.setState({
+    setResultsState({...resultsState, 
       filter: filters,
     });
 
     if (index > -1) {
       filters.splice(index, 1); // 2nd parameter means remove one item only
-      this.setState({
+      setResultsState({...resultsState, 
         filter: filters,
       });
     }
 
     this.componentDidMount();
-    /*   this.setState({
+    /*   setResultsState({...resultsState, 
         queryParams: filters,
       });
   
-      this.setState({
+      setResultsState({...resultsState, 
         queryParams: name,
       }); */
   }
 
-  handleDownload = (e) => {
-    if (this.state.globalQuery !== undefined) {
-      const url = `https://sks-server-ajah-ttwto.ondigitalocean.app/search?q=${this.global.query}&doctype=activity,entity`
-      axios
-        .get(url)
-        .then((res) => {
-          this.setState({
-            downloadData: res.data.hits,
-          })
-        })
-        .catch((error) => console.log(error))
-    } else {
-      console.log('No entity was found')
-    }
-  }
+  // const handleDownload = () => {
+  //   if (resultsState.globalQuery !== undefined) {
+  //     const url = `https://sks-server-ajah-ttwto.ondigitalocean.app/search?q=${this.global.query}&doctype=activity,entity`
+  //     axios
+  //       .get(url)
+  //       .then((res) => {
+  //         setResultsState({ ...resultsState, downloadData: res.data.hits })
+  //       })
+  //       .catch((error) => console.log(error))
+  //   } else {
+  //     console.log('No entity was found')
+  //   }
+  // }
 
-  handleButton = (e) => {
+  const handleButton = (e) => {
     e.preventDefault()
 
     let filter = []
-    if (this.state.inc_activities) {
-      filter.push('activity')
-    } else if (this.state.inc_entities) {
-      filter.push('entity')
-    } else if (!this.state.inc_activities & !this.state.inc_entities) {
-      filter.push('activity,entity') //.push("entity"); //
-    } else if (this.state.inc_activities & this.state.inc_entities) {
-      filter.push('activity,entity') //.push("entity"); //
-    }
+    // if (resultsState.inc_activities) {
+    //   filter.push('activity')
+    // } else if (resultsState.inc_entities) {
+    //   filter.push('entity')
+    // } else if (!resultsState.inc_activities & !resultsState.inc_entities) {
+    //   filter.push('activity,entity') //.push("entity"); //
+    // } else if (resultsState.inc_activities & resultsState.inc_entities) {
+    //   filter.push('activity,entity') //.push("entity"); //
+    // }
 
     /*   const queryParams = queryString.parse(window.location.search);
       // const newQueries = { ...queryParams, filter: filter.toString() };
@@ -482,119 +499,126 @@ export default class ResultsPage extends Component {
       window.location.reload(false);*/
   }
 
-  render() {
-    return (
-      <main className="page projects-page mt-5">
-        <div className="container ">
-          <div className="row mt-5" id="SearchBar">
-            <SearchBar queryProp={this.state.queryProp} />
-          </div>
-          <div className="row">
-            <div className="col-2 border border-3">
-              {/* <div className="col-2"> */}
-              <div className="row">
-                <div className="col">
-                  <h4 className="mt-3">Filter Your Search</h4>
-                  <div>
-                    <form className="form--align-with-checkboxes">
-                      <hr />
-                      <div>
-                        <input
-                          className="form-check-input form__input"
-                          type="radio"
-                          checked={this.state.filter.includes('all')}
-                          id="all-type-select"
-                          name="entity"
-                          onChange={this.handleFilters}
-                        />
-                        <label htmlFor="all-type-select" className="form__radio-label">
-                          All Types
-                        </label>
-                      </div>
-                      <div>
-                        <input
-                          className="form-check-input form__input"
-                          type="radio"
-                          checked={this.state.filter.includes('entity')}
-                          id="entity-type-select"
-                          name="entity"
-                          onChange={this.handleFilters}
-                        />
-                        <label htmlFor="entity-type-select" className="form__radio-label">
-                          Organizations
-                        </label>
-                      </div>
-                      <div>
-                        <input
-                          className="form-check-input form__input"
-                          type="radio"
-                          checked={this.state.filter.includes('activity')}
-                          id="activity-type-select"
-                          name="activity"
-                          onChange={this.handleFilters}
-                        />
-                        <label
-                          htmlFor="activity-type-select"
-                          className="form__radio-label"
-                        >
-                          Activities
-                        </label>
-                      </div>
-                    </form>
-                    <form>
-                      <hr />
-                      {this.state.provinces.map((province, i) => {
-                        return (
-                          // TODO: Replace i with data relevant id
-                          <div className="form-check" key={i}>
-                            <input
-                              className="form-check-input form__input"
-                              type="checkbox"
-                              checked={this.state.location.includes(province)}
-                              id="defaultCheck1"
-                              name={province}
-                              onChange={this.handleLocation}
-                            />
-                            <label className="form-check-label">{province}</label>
-                          </div>
-                        )
-                      })}
-
-                      <div className="mt-4">
-                        <label className="form-check-label">City:</label>
-
-                        <div className="city-block">
+  return (
+    <main className="page projects-page mt-5">
+      <div className="container ">
+        <div className="row mt-5" id="SearchBar">
+          <SearchBar queryProp={resultsState.queryProp} />
+        </div>
+        <div className="row">
+          {/* SIDEBAR */}
+          <div className="col-2 border border-3">
+            {/* <div className="col-2"> */}
+            <div className="row">
+              <div className="col">
+                <h4 className="mt-3">Filter Your Search</h4>
+                <div>
+                  <form className="form--align-with-checkboxes">
+                    <hr />
+                    <div>
+                      <input
+                        className="form-check-input form__input"
+                        type="radio"
+                        checked={
+                          doctype.includes('organization') && doctype.includes('activity')
+                        }
+                        id="all-type-select"
+                        name="type-select"
+                        value="organization,activity"
+                        onChange={handleDoctypeFilter}
+                      />
+                      <label htmlFor="all-type-select" className="form__radio-label">
+                        All Types
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        className="form-check-input form__input"
+                        type="radio"
+                        checked={
+                          doctype.includes('organization') &&
+                          !doctype.includes('activity')
+                        }
+                        id="entity-type-select"
+                        name="type-select"
+                        value="organization"
+                        onChange={handleDoctypeFilter}
+                      />
+                      <label htmlFor="entity-type-select" className="form__radio-label">
+                        Organizations
+                      </label>
+                    </div>
+                    <div>
+                      <input
+                        className="form-check-input form__input"
+                        type="radio"
+                        checked={
+                          !doctype.includes('organization') &&
+                          doctype.includes('activity')
+                        }
+                        id="activity-type-select"
+                        name="type-select"
+                        value="activity"
+                        onChange={handleDoctypeFilter}
+                      />
+                      <label htmlFor="activity-type-select" className="form__radio-label">
+                        Activities
+                      </label>
+                    </div>
+                  </form>
+                  {/* <form>
+                    <hr />
+                    // {provinces.map((province) => {
+                      return (
+                        <div className="form-check" key={province}>
                           <input
-                            className="form-control rounded-pill"
-                            type="text"
-                            name={this.state.city}
-                            onChange={(e) => this.setCity(e)}
+                            className="form-check-input form__input"
+                            type="checkbox"
+                            checked={resultsState.location.includes(province)}
+                            id="defaultCheck1"
+                            name={province}
+                            onChange={handleLocation}
                           />
-                          <div>
-                            <button
-                              className="ms-2 btn btn-primary"
-                              onClick={(e) => this.searchCity(e)}
-                            >
-                              <FontAwesomeIcon
-                                className="d-inline"
-                                size="sm"
-                                icon={faSearch}
-                              />
-                            </button>
-                          </div>
+                          <label className="form-check-label">{province}</label>
+                        </div>
+                      )
+                    })}
+
+                    <div className="mt-4">
+                      <label className="form-check-label">City:</label>
+
+                      <div className="city-block">
+                        <input
+                          className="form-control rounded-pill"
+                          type="text"
+                          name={resultsState.city}
+                          onChange={(e) => setCity(e)}
+                        />
+                        <div>
+                          <button
+                            className="ms-2 btn btn-primary"
+                            onClick={(e) => searchCity(e)}
+                          >
+                            <FontAwesomeIcon
+                              className="d-inline"
+                              size="sm"
+                              icon={faSearch}
+                            />
+                          </button>
                         </div>
                       </div>
-                    </form>
-                    <hr />
-                    <p className="text-secondary">More filters coming soon!</p>
-                  </div>
-                  <div className="">
-                    <button className="btn btn-primary" onClick={this.handleButton}>
-                      Update
-                    </button>
-                  </div>
+                    </div>
+                  </form> */}
+                  <hr />
+                  <p className="text-secondary">More filters coming soon!</p>
                 </div>
-                {/* <div className="row mt-4">
+                {/* <div className="">
+                  <button className="btn btn-primary" onClick={handleButton}>
+                    Update
+                  </button>
+                </div> */}
+              </div>
+              {/* <div className="row mt-4">
                   <div className="col">
                     <h4>Terms</h4>
                     <div className="mt-3" id="FFBC">
@@ -691,70 +715,75 @@ export default class ResultsPage extends Component {
                     </div>
                   </div>
                 </div> */}
+            </div>
+          </div>
+
+          {/* SEARCH RESULTS */}
+          <div className="col-10">
+            <div className="p-3">
+              <div className="row ">
+                <div className="col">
+                  <div className="bg-light p-3">
+                    <span>Total Results: </span>
+                    <span className="badge rounded-pill bg-primary ms-2">
+                      {resultsState.total}
+                    </span>
+                  </div>
+                </div>
+                <div className="col">
+                  <div className="bg-light p-3">
+                    <span>Organizations: </span>
+                    <span className="badge rounded-pill bg-secondary ms-2">
+                      {resultsState.ent_total}
+                    </span>
+                  </div>
+                </div>
+                <div className="col">
+                  <div className="bg-light p-3">
+                    <span>Activities: </span>
+                    <span className="badge rounded-pill bg-secondary ms-2">
+                      {resultsState.act_total}
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
-            <div className="col-10">
-              <div className="p-3">
-                <div className="row ">
-                  <div className="col">
-                    <div className="bg-light p-3">
-                      <span>Total Results: </span>
-                      <span className="badge rounded-pill bg-primary ms-2">
-                        {this.state.total}
-                      </span>
-                    </div>
+            <div className="row">
+              <div className="row" id="searchResults">
+                <div className="col">
+                  <div className="mt-2">
+                    <h4>Search Results</h4>
                   </div>
-                  <div className="col">
-                    <div className="bg-light p-3">
-                      <span>Organizations: </span>
-                      <span className="badge rounded-pill bg-secondary ms-2">
-                        {this.state.ent_total}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="col">
-                    <div className="bg-light p-3">
-                      <span>Activities: </span>
-                      <span className="badge rounded-pill bg-secondary ms-2">
-                        {this.state.act_total}
-                      </span>
-                    </div>
-                  </div>
+                  {resultsState.globalQuery && (
+                    <a href={resultsState.downloadLink}>Download Results</a>
+                  )}
                 </div>
               </div>
               <div className="row">
-                <div className="row" id="searchResults">
-                  <div className="col">
-                    <div className="mt-2">
-                      <h4>Search Results</h4>
-                    </div>
-                    {this.state.globalQuery && (
-                      <a href={this.state.downloadLink}>Download Results</a>
-                    )}
-                  </div>
-                </div>
-                <div className="row">
-                  <div className="col">
-                    {/* <div>{this.tableRows()}</div> */}
-                    <table className="table table-striped">
-                      <thead className="thead-light">
-                        <tr>
-                          <th style={{ width: '55%' }} scope="col">
-                            Name
-                          </th>
-                          <th scope="col">Location</th>
-                          <th scope="col">Record Type</th>
-                        </tr>
-                      </thead>
-                      <tbody>{this.tableRows()}</tbody>
-                    </table>
-                  </div>
+                <div className="col">
+                  {/* <div>{this.tableRows()}</div> */}
+                  <table className="table table-striped">
+                    <thead className="thead-light">
+                      <tr>
+                        <th style={{ width: '55%' }} scope="col">
+                          Name
+                        </th>
+                        <th scope="col">Location</th>
+                        <th scope="col">Record Type</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <TableRows results={resultsState.results} />
+                    </tbody>
+                  </table>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </main>
-    )
-  }
+      </div>
+    </main>
+  )
 }
+
+export default ResultsPage


### PR DESCRIPTION
Part one of a two part search mechanics refactor.
In this PR:
- Refactors to move away from using search reactcontext for state handling, and towards the address bar as the single source of truth of search state
- Resolves https://github.com/ajah/sks-interface/issues/30
- Adds ability to choose the doc type filter via radio button menu for every search call (before some were always hardcoded to eg, search both activities and orgs)
  - This partly resolves https://github.com/ajah/sks-interface/issues/32 and https://github.com/ajah/sks-interface/issues/4
  - Removes unnecessary 'Update' filters button, since as per Gustavo, search should update automatically
- Fixes issue/discrepancy with Enter key vs clicking 'Search'

To come in part two early next week:
- add support for remaining existing filters (municipality, location, etc)
- add support for multiple (previously entered) keywords, as indicated by little tiles above search box
- move all axios api calls into api service file
- resolve a few other current issues (eg https://github.com/ajah/sks-interface/issues/38)

Note: a lot of the old code is still left commented out for reference 