### PR TITLE
Allows search with only filters + downloaded data fix

### DIFF
--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -1,0 +1,15 @@
+import { ACTIVITY, ORGANIZATION } from 'constants'
+
+const Badge = ({ type }) => {
+  if (type === ACTIVITY) {
+    return <span className="badge badge-primary">Activity</span>
+  }
+
+  if (type === ORGANIZATION) {
+    return <span className="badge bg-primary">Organization</span>
+  }
+
+  return null
+}
+
+export default Badge

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,0 +1,3 @@
+import Badge from './Badge'
+
+export { Badge }

--- a/src/components/SidebarFilterTerms/SidebarFilterTerms.js
+++ b/src/components/SidebarFilterTerms/SidebarFilterTerms.js
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { kebabCase, toLower } from 'lodash'
+import { GoTriangleDown, GoTriangleRight } from 'react-icons/go'
+
+const SidebarFilterTerms = ({
+  category,
+  categoryDisplay,
+  termsUsed,
+  termsDisplay,
+  onChangeHandler,
+}) => {
+  const [termsOpen, setTermsOpen] = useState(true)
+
+  return (
+    <div className="mt-3" key={category}>
+      <strong>
+        <button className="sidebar-btn" onClick={() => setTermsOpen(!termsOpen)}>
+          {termsOpen ? <GoTriangleDown /> : <GoTriangleRight />} {categoryDisplay}
+        </button>
+      </strong>
+      {termsOpen &&
+        termsDisplay.map((term) => {
+          const key = `${category}_${toLower(term)}`
+
+          return (
+            <div className="form-check mt-1" key={key}>
+              <input
+                className="form-check-input"
+                type="checkbox"
+                onChange={() => onChangeHandler(key)}
+                checked={termsUsed.includes(key)}
+                id={kebabCase(key)}
+              />
+              <label className="form-check-label" htmlFor={kebabCase(key)}>
+                {term}
+              </label>
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+export default SidebarFilterTerms

--- a/src/components/SidebarFilterTerms/index.js
+++ b/src/components/SidebarFilterTerms/index.js
@@ -1,0 +1,3 @@
+import SidebarFilterTerms from './SidebarFilterTerms'
+
+export { SidebarFilterTerms }

--- a/src/components/TableRows/TableRows.js
+++ b/src/components/TableRows/TableRows.js
@@ -1,0 +1,73 @@
+import { Link, useLocation } from 'react-router-dom'
+
+import { Badge } from 'components/Badge'
+
+import { ACTIVITY, ORGANIZATION } from 'constants'
+
+const TableRows = ({ results }) => {
+  const location = useLocation()
+
+  return results.map(({ _id, _index, _source }) => {
+    let name
+    let city
+    let region
+    let type
+    let url
+
+    if (_index === 'new-activities') {
+      name = _source.grant_title
+      city = _source.grant_municipality
+      region = _source.grant_region
+      type = ACTIVITY
+      url = `/activities/${_source.act_sks_id}`
+    }
+
+    if (_index === 'entities') {
+      name = _source.name
+      city = _source.location_municipality
+      region = _source.location_region
+      type = ORGANIZATION
+      url = `/organizations/${_source.ent_sks_id}`
+    }
+
+    return (
+      <Row
+        key={_id}
+        location={location}
+        name={name}
+        city={city}
+        region={region}
+        type={type}
+        url={url}
+      />
+    )
+  })
+}
+
+const Row = (props) => (
+  <tr>
+    <td>
+      <div>
+        <Link
+          to={props.url}
+          state={{ from: `${props.location.pathname}${props.location.search}` }}
+        >
+          {props.name}
+        </Link>
+      </div>
+    </td>
+    <td>
+      <div>
+        {props.city}
+        {props.region ? `, ${props.region}` : ''}
+      </div>
+    </td>
+    <td>
+      <div>
+        <Badge type={props.type} />
+      </div>
+    </td>
+  </tr>
+)
+
+export default TableRows

--- a/src/components/TableRows/index.js
+++ b/src/components/TableRows/index.js
@@ -1,0 +1,3 @@
+import TableRows from './TableRows'
+
+export { TableRows }

--- a/src/views/SearchPage.js
+++ b/src/views/SearchPage.js
@@ -9,11 +9,13 @@ import {
   without,
   uniq,
 } from 'lodash'
-import { Link, useLocation } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus, faTimesCircle } from '@fortawesome/free-solid-svg-icons'
-import { GoTriangleDown, GoTriangleRight } from 'react-icons/go'
+
 import { SearchBar } from 'components/SearchBar'
+import { SidebarFilterTerms } from 'components/SidebarFilterTerms'
+import { TableRows } from 'components/TableRows'
+
 import { SearchContext } from 'context/search-context'
 import { useSearchParams } from 'hooks'
 import { createDownloadLink, Get } from 'services/api'
@@ -40,123 +42,6 @@ import {
 // TODO: move styles.css import into SearchPage.css
 import 'assets/css/styles.css'
 import './SearchPage.css'
-
-const Badge = ({ type }) => {
-  if (type === ACTIVITY) {
-    return <span className="badge badge-primary">Activity</span>
-  }
-
-  if (type === ORGANIZATION) {
-    return <span className="badge bg-primary">Organization</span>
-  }
-
-  return null
-}
-
-const Row = (props) => (
-  <tr>
-    <td>
-      <div>
-        <Link
-          to={props.url}
-          state={{ from: `${props.location.pathname}${props.location.search}` }}
-        >
-          {props.name}
-        </Link>
-      </div>
-    </td>
-    <td>
-      <div>
-        {props.city}
-        {props.region ? `, ${props.region}` : ''}
-      </div>
-    </td>
-    <td>
-      <div>
-        <Badge type={props.type} />
-      </div>
-    </td>
-  </tr>
-)
-
-const TableRows = ({ results }) => {
-  const location = useLocation()
-
-  return results.map(({ _id, _index, _source }) => {
-    let name
-    let city
-    let region
-    let type
-    let url
-
-    if (_index === 'new-activities') {
-      name = _source.grant_title
-      city = _source.grant_municipality
-      region = _source.grant_region
-      type = ACTIVITY
-      url = `/activities/${_source.act_sks_id}`
-    }
-
-    if (_index === 'entities') {
-      name = _source.name
-      city = _source.location_municipality
-      region = _source.location_region
-      type = ORGANIZATION
-      url = `/organizations/${_source.ent_sks_id}`
-    }
-
-    return (
-      <Row
-        key={_id}
-        location={location}
-        name={name}
-        city={city}
-        region={region}
-        type={type}
-        url={url}
-      />
-    )
-  })
-}
-
-const SidebarFilterTerms = ({
-  category,
-  categoryDisplay,
-  termsUsed,
-  termsDisplay,
-  onChangeHandler,
-}) => {
-  const [termsOpen, setTermsOpen] = useState(true)
-
-  return (
-    <div className="mt-3" key={category}>
-      <strong>
-        <button className="sidebar-btn" onClick={() => setTermsOpen(!termsOpen)}>
-          {termsOpen ? <GoTriangleDown /> : <GoTriangleRight />} {categoryDisplay}
-        </button>
-      </strong>
-      {termsOpen &&
-        termsDisplay.map((term) => {
-          const key = `${category}_${toLower(term)}`
-
-          return (
-            <div className="form-check mt-1" key={key}>
-              <input
-                className="form-check-input"
-                type="checkbox"
-                onChange={() => onChangeHandler(key)}
-                checked={termsUsed.includes(key)}
-                id={kebabCase(key)}
-              />
-              <label className="form-check-label" htmlFor={kebabCase(key)}>
-                {term}
-              </label>
-            </div>
-          )
-        })}
-    </div>
-  )
-}
 
 const initialResultsState = {
   // TODO: Review state vars below and see which are unnecessry
@@ -390,36 +275,6 @@ const SearchPage = () => {
 
     handleCityFilter(e)
   }
-
-  // const handleButton = (e) => {
-  //   e.preventDefault()
-
-  //   let filter = []
-  // if (resultsState.incActivities) {
-  //   filter.push(ACTIVITY)
-  // } else if (resultsState.incOrganizations) {
-  //   filter.push('entity')
-  // } else if (!resultsState.incActivities & !resultsState.incOrganizations) {
-  //   filter.push('activity,entity') //.push("entity"); //
-  // } else if (resultsState.incActivities & resultsState.incOrganizations) {
-  //   filter.push('activity,entity') //.push("entity"); //
-  // }
-
-  /*   const queryParams = queryString.parse(window.location.search);
-      // const newQueries = { ...queryParams, filter: filter.toString() };
-      const orig_q = queryParams["q"];
-  
-      const { history } = this.props;
-  
-      if (filter) {
-        history.push(`/search?q=${orig_q}&filter=${filter.toString()}`);
-        window.location.reload(false);
-        setFilter(filter.toString)
-      }
-  
-      history.push(`/search?q=${encodeURI(orig_q)}&filter=${filter.toString()}`);
-      window.location.reload(false);*/
-  // }
 
   // TODO: Move city filter into own component along with line below:
   const cityInputDisabled =

--- a/src/views/SearchPage.js
+++ b/src/views/SearchPage.js
@@ -96,7 +96,6 @@ const SearchPage = () => {
       }
 
       // Check 'q'
-      if (!qStr) return setResultsState(initialResultsState)
       const qArr = castArray(q)
 
       // Each query term should be limited to maxQueryTermLength chars
@@ -148,7 +147,10 @@ const SearchPage = () => {
       const termsArr = termsStr ? termsStr.split(',') : []
 
       const parsedTermsArr = uniq(termsArr).filter((catAndTerm) => {
-        const [catLower, termLower] = catAndTerm.split('_').map(toLower)
+        const [catLower, termLower] = catAndTerm
+          .split('_')
+          .map(toLower)
+          .map((s) => s.trim())
 
         if (!catLower || !termLower) return false
 
@@ -157,6 +159,14 @@ const SearchPage = () => {
 
         return true
       })
+
+      const incompleteParams =
+        !parsedQArr.length &&
+        !parsedCityArr.length &&
+        !parsedTermsArr.length &&
+        !parsedRegionArr.length
+
+      if (incompleteParams) return setResultsState(initialResultsState)
 
       const changedParams =
         qStr.length !== parsedQArr.toString().length ||
@@ -523,6 +533,7 @@ const SearchPage = () => {
                         doctype,
                         operator,
                         region,
+                        terms,
                       })}
                     >
                       Download Results


### PR DESCRIPTION
The search functionality currently requires a search keyword entered into the text box for the search to initiate. Current PR enables searching & fetching results when any of the following are present:
- Search keywords
- City
- Province
- Sidebar checkbox filter terms

Also:
Fixes downloaded data request not taking into consideration Sidebar checkbox filter terms 

Resolves: https://github.com/ajah/sks-interface/issues/66